### PR TITLE
Remove $TEMP_KERNEL_DIR after successful update

### DIFF
--- a/bp-update
+++ b/bp-update
@@ -77,7 +77,8 @@ upgradeKernel()
 		chmod +x $TEMP_KERNEL_DIR/bp-kernel-update
 	fi
 	
-	$TEMP_KERNEL_DIR/bp-kernel-update $1 $TEMP_KERNEL_DIR
+	$TEMP_KERNEL_DIR/bp-kernel-update $1 $TEMP_KERNEL_DIR && \
+		rm -rf $TEMP_KERNEL_DIR
 }
 
 upgradeRootfs()


### PR DESCRIPTION
As /tmp is persistent on some images (e.g. Fedora), remove /tmp/kernel.tmp after successful kernel update.
